### PR TITLE
new feature on c.nanorc

### DIFF
--- a/c.nanorc
+++ b/c.nanorc
@@ -52,9 +52,11 @@ color magenta "\<(auto|extern|register|static)\>"
 color magenta "\<(inline|sizeof|typedef|goto|break|continue|return|enum|struct|union)\>"
 
 ## char, string, and escape sequence
-color brightyellow "'([^'\]|\\([abfnrtv\'"?]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}))'"
-color brightyellow "\"([^"\]|\\([abfnrtv\'"?]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}))*\""
-color cyan "\\([abfnrtv\'"?]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2})"
+## \e or \x1B or \033 -> Escape, beginning of ANSI escape sequence
+## \e[ or \x1B[ or \033[ -> beginning of CSI sequence
+color brightyellow "'([^'\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?))'"
+color brightyellow "\"([^"\]|([^'\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?)))*\""
+color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?)"
 
 ## Suffix blank
 color ,lightgreen "\s+$"

--- a/c.nanorc
+++ b/c.nanorc
@@ -55,7 +55,7 @@ color magenta "\<(inline|sizeof|typedef|goto|break|continue|return|enum|struct|u
 ## \e or \x1B or \033 -> Escape, beginning of ANSI escape sequence
 ## \e[ or \x1B[ or \033[ -> beginning of CSI sequence
 color brightyellow "'([^'\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?))'"
-color brightyellow "\"([^"\]|([^'\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?)))*\""
+color brightyellow "\"([^"\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?))*\""
 color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?)"
 
 ## Suffix blank

--- a/c.nanorc
+++ b/c.nanorc
@@ -9,14 +9,14 @@ color green ";"
 
 ## Number (int and floating-point)
 icolor blue "[+-]?\<([1-9][0-9]*|0x[[:xdigit:]]+|0[0-7]*|0b[01]+)[UL]*\>"
-icolor blue "[+-]?\<[0-9]+\.(e[+-]?[0-9]+\>)?"
-icolor blue "[+-]?\.[0-9]+(e[+-]?[0-9]+)?\>"
-  ## Unmark +- used as operator
+icolor blue "[+-]?\<[0-9]+\.((e[+-]?[0-9]+)?[fL]?\>)?"
+icolor blue "[+-]?\.[0-9]+(e[+-]?[0-9]+)?[fL]?\>"
+  ## Unmark +- used for plus and minus
 icolor normal "[[:alnum:]]\s*[+-]"
   ## mark number again
-icolor blue "\<([1-9][0-9]*|0x[[:xdigit:]]+|0[0-7]*|0b[01]+)\>"
-icolor blue "\<[0-9]+\.e[+-]?[0-9]+\>"
-icolor blue "\.[0-9]+e[+-]?[0-9]+\>"
+icolor blue "\<([1-9][0-9]*|0x[[:xdigit:]]+|0[0-7]*|0b[01]+)[UL]*\>"
+icolor blue "\<[0-9]+\.(e[+-]?[0-9]+)?[fL]?\>"
+icolor blue "\.[0-9]+(e[+-]?[0-9]+)?[fL]?\>"
 
 ## Preprocessor
 color brightblue "\\$"

--- a/c.nanorc
+++ b/c.nanorc
@@ -1,3 +1,4 @@
+## std: c11
 syntax c "\.c$"
 comment "/*|*/"
 
@@ -26,9 +27,11 @@ color red "^#error.*$"
 color brightblue "^#(define|undef|error|include|line|pragma)" "#"
 color brightblue "^#(if|ifdef|ifndef|elif|else|endif)" "\<defined\>"
 
-## Macro
+## Macro and constants
 color brightred "\<[[:upper:]_][[:upper:][:digit:]_]*\>"
 color brightred "\<(true|false|__cplusplus|__func__)\>"
+  ## constant in <stdio.h>
+color brightred "\<std(in|out|err)\>"
   ## defined in <inttypes.h>
 color brightred "\<PRI[diouxX]((LEAST|FAST)?[[:digit:]]+|MAX|PTR)\>"
 color brightred "\<SCN[dioux]((LEAST|FAST)?[[:digit:]]+|MAX|PTR)\>"
@@ -42,6 +45,7 @@ color brightgreen "\<(const|restrict|volatile)\>"
 
 ## label
 color cyan "^\s*[[:alpha:]_][[:alnum:]_]*\s*:"
+color cyan "\<goto\s+[[:alpha:]_][[:alnum:]_]*"
 color normal ":"
 
 ## flow

--- a/c.nanorc
+++ b/c.nanorc
@@ -51,12 +51,15 @@ color yellow "\<(while|for|do|if|else|switch|case|default)\>"
 color magenta "\<(auto|extern|register|static)\>"
 color magenta "\<(inline|sizeof|typedef|goto|break|continue|return|enum|struct|union)\>"
 
-## char, string, and escape sequence
+## char, string, and escape character/sequence
 ## \e or \x1B or \033 -> Escape, beginning of ANSI escape sequence
 ## \e[ or \x1B[ or \033[ -> beginning of CSI sequence
-color brightyellow "'([^'\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?))'"
-color brightyellow "\"([^"\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?))*\""
-color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?)"
+color brightyellow "'([^'\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+))'"
+color brightyellow "\"([^"\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+))*\""
+##    CSI sequence
+color brightyellow,cyan "\\(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?"
+##    Escape character
+color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+)"
 
 ## Suffix blank
 color ,lightgreen "\s+$"

--- a/c.nanorc
+++ b/c.nanorc
@@ -15,9 +15,10 @@ icolor blue "[+-]?\.[0-9]+(e[+-]?[0-9]+)?[fL]?\>"
   ## Unmark +- used for plus and minus
 icolor normal "[[:alnum:]]\s*[+-]"
   ## mark number again
-icolor blue "\<([1-9][0-9]*|0x[[:xdigit:]]+|0[0-7]*|0b[01]+)[UL]*\>"
-icolor blue "\<[0-9]+\.(e[+-]?[0-9]+)?[fL]?\>"
-icolor blue "\.[0-9]+(e[+-]?[0-9]+)?[fL]?\>"
+  ## mark the +- behind "return" keyword
+icolor blue "\<(return\s+[+-])?([1-9][0-9]*|0x[[:xdigit:]]+|0[0-7]*|0b[01]+)[UL]*\>"
+icolor blue "\<(return\s+[+-])?[0-9]+\.(e[+-]?[0-9]+)?[fL]?\>"
+icolor blue "(\<return\s+[+-])?\.[0-9]+(e[+-]?[0-9]+)?[fL]?\>"
 
 ## Preprocessor
 color brightblue "\\$"

--- a/c.nanorc
+++ b/c.nanorc
@@ -54,9 +54,9 @@ color magenta "\<(inline|sizeof|typedef|goto|break|continue|return|enum|struct|u
 ## char, string, and escape sequence
 ## \e or \x1B or \033 -> Escape, beginning of ANSI escape sequence
 ## \e[ or \x1B[ or \033[ -> beginning of CSI sequence
-color brightyellow "'([^'\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?))'"
-color brightyellow "\"([^"\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?))*\""
-color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?)"
+color brightyellow "'([^'\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?))'"
+color brightyellow "\"([^"\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?))*\""
+color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+|(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?)"
 
 ## Suffix blank
 color ,lightgreen "\s+$"


### PR DESCRIPTION
More complete support on number:
- f or L appear behind floating-point number

New constants:
- stdin
- stdout
- stderr

Color commonly-used CSI escape sequence

Color label behind "goto" keyword

Buf Fix:
- fix the problem that positive and negative sign behind "return" keyword can't be correctly colored