### PR TITLE
new feature on c.nanorc cpp.nanorc

### DIFF
--- a/c.nanorc
+++ b/c.nanorc
@@ -1,5 +1,10 @@
+## Syntax Highlight for C language
 ## std: c11
-syntax c "\.c$"
+
+syntax c "\.[chi]$"
+## File Variable in Emacs
+header "-\*-.*\<mode: c;.*-\*-"
+magic "^C (source|program)"
 comment "/*|*/"
 
 ## Mark backslash placed in wrong place as red

--- a/c.nanorc
+++ b/c.nanorc
@@ -27,11 +27,11 @@ icolor blue "(\<return\s+[+-])?\.[0-9]+(e[+-]?[0-9]+)?[fL]?\>"
 
 ## Preprocessor
 color brightblue "\\$"
-color brightyellow "^#include\s+<.*>\s*(//.*|/\*.*)?$"
-color brightyellow "^#include\s+\".*\"\s*(//.*|/\*.*)?$"
-color red "^#error.*$"
-color brightblue "^#(define|undef|error|include|line|pragma)" "#"
-color brightblue "^#(if|ifdef|ifndef|elif|else|endif)" "\<defined\>"
+color brightyellow "^\s*#include\s+<.*>\s*(//.*|/\*.*)?$"
+color brightyellow "^\s*#include\s+\".*\"\s*(//.*|/\*.*)?$"
+color red "^\s*#error.*$"
+color brightblue "^\s*#(define|undef|error|include|line|pragma)" "#"
+color brightblue "^\s*#(if|ifdef|ifndef|elif|else|endif)" "\<defined\>"
 
 ## Macro and constants
 color brightred "\<[[:upper:]_][[:upper:][:digit:]_]*\>"

--- a/c.nanorc
+++ b/c.nanorc
@@ -74,7 +74,8 @@ color brightyellow,cyan "\\(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?"
 color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+)"
 
 ## Comment
-color italic,lightblack "//.*$"
+color italic,lightblack "//.*|/\*.*\*/"
+color italic,lightblack start="//.*[\]$" end="(^|[^\])$"
 color italic,lightblack start="/\*" end="\*/"
 
 ## Suffix blank

--- a/c.nanorc
+++ b/c.nanorc
@@ -36,7 +36,7 @@ color brightblue "^#(if|ifdef|ifndef|elif|else|endif)" "\<defined\>"
 ## Macro and constants
 color brightred "\<[[:upper:]_][[:upper:][:digit:]_]*\>"
 color brightred "\<(true|false|__cplusplus|__func__)\>"
-  ## constant in <stdio.h>
+  ## constants in <stdio.h>
 color brightred "\<std(in|out|err)\>"
   ## defined in <inttypes.h>
 color brightred "\<PRI[diouxX]((LEAST|FAST)?[[:digit:]]+|MAX|PTR)\>"
@@ -44,7 +44,8 @@ color brightred "\<SCN[dioux]((LEAST|FAST)?[[:digit:]]+|MAX|PTR)\>"
 
 ## type
 color green "\<([[:alpha:]_][[:alnum:]_]*_t|bool|FILE)\>"
-color green "\<(void|int|signed|unsigned|short|long|float|double|char|wchar_t|_Bool)\>"
+color green "\<(void|int|signed|unsigned|short|long|float|double|char)\>"
+color green "\<_(Atomic|Bool|Complex|Imaginary|Thread_local)\>"
 
 ## type qualifier
 color brightgreen "\<(const|restrict|volatile)\>"
@@ -60,6 +61,8 @@ color yellow "\<(while|for|do|if|else|switch|case|default)\>"
 ## storage-duration qualifier and other keywords
 color magenta "\<(auto|extern|register|static)\>"
 color magenta "\<(inline|sizeof|typedef|goto|break|continue|return|enum|struct|union)\>"
+color magenta "\<(__asm__|asm|fortran)\>"
+color magenta "\<_(Alignas|Alignof|Generic|Noreturn|Pragma|Static_assert)\>"
 
 ## char, string, and escape character/sequence
 ## \e or \x1B or \033 -> Escape, beginning of ANSI escape sequence
@@ -71,9 +74,9 @@ color brightyellow,cyan "\\(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?"
 ##    Escape character
 color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+)"
 
-## Suffix blank
-color ,lightgreen "\s+$"
-
 ## Comment
 color italic,lightblack "//.*$"
 color italic,lightblack start="/\*" end="\*/"
+
+## Suffix blank
+color ,lightgreen "\s+$"

--- a/c.nanorc
+++ b/c.nanorc
@@ -32,6 +32,7 @@ color brightyellow "^\s*#include\s+\".*\"\s*(//.*|/\*.*)?$"
 color red "^\s*#error\s.*$"
 color brightblue "^\s*#(define|undef|error|include|line|pragma)\s" "#"
 color brightblue "^\s*#(if|ifdef|ifndef|elif|else|endif)\s" "\<defined\>"
+color brightblue "^\s*_Pragma"
 
 ## Macro and constants
 color brightred "\<[[:upper:]_][[:upper:][:digit:]_]*\>"
@@ -50,17 +51,17 @@ color normal ":"
 ## type
 color green "\<([[:alpha:]_][[:alnum:]_]*_t|bool|FILE)\>"
 color green "\<(void|int|signed|unsigned|short|long|float|double|char)\>"
-color green "\<_(Atomic|Bool|Complex|Imaginary|Thread_local)\>"
+color green "\<_(Atomic|Bool|Complex|Imaginary)\>"
 color brightgreen "\<(const|restrict|volatile)\>"
 
 ## flow
 color yellow "\<(while|for|do|if|else|switch|case|default)\>"
 
 ## storage-duration qualifier and other keywords
-color magenta "\<(auto|extern|register|static)\>"
+color magenta "\<(auto|extern|register|static|_Thread_local)\>"
 color magenta "\<(inline|sizeof|typedef|goto|break|continue|return|enum|struct|union)\>"
 color magenta "\<(__asm__|asm|fortran)\>"
-color magenta "\<_(Alignas|Alignof|Generic|Noreturn|Pragma|Static_assert)\>"
+color magenta "\<_(Alignas|Alignof|Generic|Noreturn|Static_assert)\>"
 
 ## char, string, and escape character/sequence
 ## \e or \x1B or \033 -> Escape, beginning of ANSI escape sequence

--- a/c.nanorc
+++ b/c.nanorc
@@ -42,18 +42,16 @@ color brightred "\<std(in|out|err)\>"
 color brightred "\<PRI[diouxX]((LEAST|FAST)?[[:digit:]]+|MAX|PTR)\>"
 color brightred "\<SCN[dioux]((LEAST|FAST)?[[:digit:]]+|MAX|PTR)\>"
 
-## type
-color green "\<([[:alpha:]_][[:alnum:]_]*_t|bool|FILE)\>"
-color green "\<(void|int|signed|unsigned|short|long|float|double|char)\>"
-color green "\<_(Atomic|Bool|Complex|Imaginary|Thread_local)\>"
-
-## type qualifier
-color brightgreen "\<(const|restrict|volatile)\>"
-
 ## label
 color cyan "^\s*[[:alpha:]_][[:alnum:]_]*\s*:"
 color cyan "\<goto\s+[[:alpha:]_][[:alnum:]_]*"
 color normal ":"
+
+## type
+color green "\<([[:alpha:]_][[:alnum:]_]*_t|bool|FILE)\>"
+color green "\<(void|int|signed|unsigned|short|long|float|double|char)\>"
+color green "\<_(Atomic|Bool|Complex|Imaginary|Thread_local)\>"
+color brightgreen "\<(const|restrict|volatile)\>"
 
 ## flow
 color yellow "\<(while|for|do|if|else|switch|case|default)\>"

--- a/c.nanorc
+++ b/c.nanorc
@@ -29,9 +29,9 @@ icolor blue "(\<return\s+[+-])?\.[0-9]+(e[+-]?[0-9]+)?[fL]?\>"
 color brightblue "\\$"
 color brightyellow "^\s*#include\s+<.*>\s*(//.*|/\*.*)?$"
 color brightyellow "^\s*#include\s+\".*\"\s*(//.*|/\*.*)?$"
-color red "^\s*#error.*$"
-color brightblue "^\s*#(define|undef|error|include|line|pragma)" "#"
-color brightblue "^\s*#(if|ifdef|ifndef|elif|else|endif)" "\<defined\>"
+color red "^\s*#error\s.*$"
+color brightblue "^\s*#(define|undef|error|include|line|pragma)\s" "#"
+color brightblue "^\s*#(if|ifdef|ifndef|elif|else|endif)\s" "\<defined\>"
 
 ## Macro and constants
 color brightred "\<[[:upper:]_][[:upper:][:digit:]_]*\>"

--- a/cpp.nanorc
+++ b/cpp.nanorc
@@ -45,7 +45,7 @@ color normal ":"
 # Types and related keywords.
 color green "\<(bool|char|double|float|int|long|short|signed|unsigned|void)\>"
 color green "\<([[:alpha:]_][[:alnum:]_]*_t|FILE)\>"
-color green "\<(const|mutable|restrict|volatile)\>"
+color lightgreen "\<(const|mutable|restrict|volatile)\>"
 color green "\<_(Atomic|Bool|Complex|Imaginary|Thread_local)\>"
 color magenta "\<_(Alignas|Alignof|Generic|Noreturn|Pragma|Static_assert)\>"
 color magenta "\<(__asm__|asm|auto|class|enum|explicit|extern|false|friend|inline|namespace|override|private|protected|public|register|sizeof|static|struct|typedef|union||template|this|true|typename|using|virtual|operator|new|delete)\>"
@@ -77,8 +77,8 @@ color brightyellow,cyan "\\(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?"
 color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+)"
 
 # Comments.
-color brightblue "//.*"
-color brightblue start="/\*" end="\*/"
+color italic,lightblack "//.*"
+color italic,lightblack start="/\*" end="\*/"
 
 # Trailing whitespace.
 color ,green "[[:space:]]+$"

--- a/cpp.nanorc
+++ b/cpp.nanorc
@@ -1,4 +1,5 @@
 ## Syntax highlighting for C++ files.
+## std: c++11
 
 syntax cpp "\.([ch](pp|xx)|C|cc|c\+\+|H|hh|ii)$"
 ## File Variable in Emacs
@@ -6,42 +7,78 @@ header "-\*-.*\<mode: c\+\+;.*-\*-"
 magic "^C\+\+ (source|program)"
 comment "//"
 
-# Constants.
-color brightred "\<[A-Z_][0-9A-Z_]*\>"
-# Labels.
-color brightmagenta "^[[:blank:]]*[A-Z_a-z][0-9A-Z_a-z]*:[[:blank:]]*$"
-color normal ":[[:blank:]]*$"
+## Mark backslash placed in wrong place as red
+color red "\\"
+
+## Mark ;
+color green ";"
+
+## Number (int and floating-point)
+icolor blue "[+-]?\<([1-9][0-9]*|0x[[:xdigit:]]+|0[0-7]*|0b[01]+)[UL]*\>"
+icolor blue "[+-]?\<[0-9]+\.((e[+-]?[0-9]+)?[fL]?\>)?"
+icolor blue "[+-]?\.[0-9]+(e[+-]?[0-9]+)?[fL]?\>"
+  ## Unmark +- used for plus and minus
+icolor normal "[[:alnum:]]\s*[+-]"
+  ## mark number again
+  ## mark the +- behind "return" keyword
+icolor blue "\<(return\s+[+-])?([1-9][0-9]*|0x[[:xdigit:]]+|0[0-7]*|0b[01]+)[UL]*\>"
+icolor blue "\<(return\s+[+-])?[0-9]+\.(e[+-]?[0-9]+)?[fL]?\>"
+icolor blue "(\<return\s+[+-])?\.[0-9]+(e[+-]?[0-9]+)?[fL]?\>"
+
+## Macro and constants
+color brightred "\<[[:upper:]_][[:upper:][:digit:]_]*\>"
+color brightred "\<(__cplusplus|__func__)\>"
+  ## constants in <stdio.h>
+color brightred "\<std(in|out|err)\>"
+  ## defined in <inttypes.h>
+color brightred "\<PRI[diouxX]((LEAST|FAST)?[[:digit:]]+|MAX|PTR)\>"
+color brightred "\<SCN[dioux]((LEAST|FAST)?[[:digit:]]+|MAX|PTR)\>"
+
+## label
+color cyan "^\s*[[:alpha:]_][[:alnum:]_]*\s*:"
+color cyan "\<goto\s+[[:alpha:]_][[:alnum:]_]*"
+
+# namespace
+color brightred "\<std\>"
+color normal ":"
 
 # Types and related keywords.
-color green "\<(auto|bool|char|const|double|enum|extern|float|inline|int|long|restrict|short|signed|sizeof|static|struct|typedef|union|unsigned|void)\>"
-color green "\<([[:lower:]][[:lower:]_]*|(u_?)?int(8|16|32|64))_t\>"
-color green "\<(_(Alignas|Alignof|Atomic|Bool|Complex|Generic|Imaginary|Noreturn|Static_assert|Thread_local))\>"
-color green "\<(class|explicit|friend|mutable|namespace|override|private|protected|public|register|template|this|typename|using|virtual|volatile)\>"
+color green "\<(bool|char|double|float|int|long|short|signed|unsigned|void)\>"
+color green "\<([[:alpha:]_][[:alnum:]_]*_t|FILE)\>"
+color green "\<(const|mutable|restrict|volatile)\>"
+color green "\<_(Atomic|Bool|Complex|Imaginary|Thread_local)\>"
+color magenta "\<_(Alignas|Alignof|Generic|Noreturn|Pragma|Static_assert)\>"
+color magenta "\<(__asm__|asm|auto|class|enum|explicit|extern|false|friend|inline|namespace|override|private|protected|public|register|sizeof|static|struct|typedef|union||template|this|true|typename|using|virtual|operator|new|delete)\>"
 
 # Flow control.
 color brightyellow "\<(if|else|for|while|do|switch|case|default)\>"
-color brightyellow "\<(try|throw|catch|operator|new|delete)\>"
+color brightyellow "\<(try|throw|catch)\>"
 color magenta "\<(break|continue|goto|return)\>"
 
-# Single-quoted stuff (characters, backslash escapes, hex and octal byte codes).
-color brightmagenta "'([^'\]|\\(["'\abfnrtv]|x[[:xdigit:]]{1,2}|[0-3]?[0-7]{1,2}))'"
-
 # GCC builtins.
-color cyan "__attribute__[[:blank:]]*\(\([^)]*\)\)|__(aligned|asm|builtin|hidden|inline|packed|restrict|section|typeof|weak)__"
+# color cyan "__attribute__[[:blank:]]*\(\([^)]*\)\)|__(aligned|asm|builtin|hidden|inline|packed|restrict|section|typeof|weak)__"
 
-# Strings and names of included files.
-color brightyellow ""([^"]|\\")*"|#[[:blank:]]*include[[:blank:]]*<[^>]+>"
+## Preprocessor
+color brightblue "\\$"
+color brightyellow "^\s*#include\s+<.*>\s*(//.*|/\*.*)?$"
+color brightyellow "^\s*#include\s+\".*\"\s*(//.*|/\*.*)?$"
+color red "^\s*#error.*$"
+color brightblue "^\s*#(define|undef|error|include|line|pragma)" "#"
+color brightblue "^\s*#(if|ifdef|ifndef|elif|else|endif)" "\<defined\>"
 
-# Preprocessor directives.
-color brightcyan start="^[[:blank:]]*#[[:blank:]]*(if(n?def)?|elif|warning|error|pragma)\>" end="(\`|[^\])$"
-color brightcyan "^[[:blank:]]*#[[:blank:]]*((define|else|endif|include(_next)?|line|undef)\>|$)"
+## char, string, and escape character/sequence
+## \e or \x1B or \033 -> Escape, beginning of ANSI escape sequence
+## \e[ or \x1B[ or \033[ -> beginning of CSI sequence
+color brightyellow "'([^'\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+))'"
+color brightyellow "\"([^"\]|\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+))*\""
+##    CSI sequence
+color brightyellow,cyan "\\(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?"
+##    Escape character
+color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+)"
 
 # Comments.
 color brightblue "//.*"
 color brightblue start="/\*" end="\*/"
-
-# Reminders.
-color brightwhite,yellow "\<(FIXME|TODO|XXX)\>"
 
 # Trailing whitespace.
 color ,green "[[:space:]]+$"

--- a/cpp.nanorc
+++ b/cpp.nanorc
@@ -79,8 +79,9 @@ color brightyellow,cyan "\\(e|x1[bB]|0?33)\[([;0-9]*[ABCDEFGHJKSTfmin])?"
 color cyan "\\([abfnrtv\'"?e]|x[[:xdigit:]]+|[0-7]+)"
 
 # Comments.
-color italic,lightblack "//.*"
+color italic,lightblack "//.*|/\*.*\*/"
+color italic,lightblack start="//.*[\]$" end="(^|[^\])$"
 color italic,lightblack start="/\*" end="\*/"
 
 # Trailing whitespace.
-color ,green "[[:space:]]+$"
+color ,lightgreen "[[:space:]]+$"

--- a/cpp.nanorc
+++ b/cpp.nanorc
@@ -62,9 +62,9 @@ color magenta "\<(break|continue|goto|return)\>"
 color brightblue "\\$"
 color brightyellow "^\s*#include\s+<.*>\s*(//.*|/\*.*)?$"
 color brightyellow "^\s*#include\s+\".*\"\s*(//.*|/\*.*)?$"
-color red "^\s*#error.*$"
-color brightblue "^\s*#(define|undef|error|include|line|pragma)" "#"
-color brightblue "^\s*#(if|ifdef|ifndef|elif|else|endif)" "\<defined\>"
+color red "^\s*#error\s.*$"
+color brightblue "^\s*#(define|undef|error|include|line|pragma)\s" "#"
+color brightblue "^\s*#(if|ifdef|ifndef|elif|else|endif)\s" "\<defined\>"
 
 ## char, string, and escape character/sequence
 ## \e or \x1B or \033 -> Escape, beginning of ANSI escape sequence

--- a/cpp.nanorc
+++ b/cpp.nanorc
@@ -45,10 +45,11 @@ color normal ":"
 # Types and related keywords.
 color green "\<(bool|char|double|float|int|long|short|signed|unsigned|void)\>"
 color green "\<([[:alpha:]_][[:alnum:]_]*_t|FILE)\>"
-color lightgreen "\<(const|mutable|restrict|volatile)\>"
-color green "\<_(Atomic|Bool|Complex|Imaginary|Thread_local)\>"
-color magenta "\<_(Alignas|Alignof|Generic|Noreturn|Pragma|Static_assert)\>"
-color magenta "\<(__asm__|asm|auto|class|enum|explicit|extern|false|friend|inline|namespace|override|private|protected|public|register|sizeof|static|struct|typedef|union||template|this|true|typename|using|virtual|operator|new|delete)\>"
+color lightgreen "\<(const|volatile)\>"
+color magenta "\<(alignas|alignof|static_assert|thread_local)\>"
+color magenta "\<(const|dynamic|reinterpret|static)_cast\>"
+color magenta "\<(and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|xor|xor_eq)\>"
+color magenta "\<(__asm__|asm|auto|class|decltype|delete|enum|explicit|extern|false|final|friend|inline|mutable|namespace|new|noexcept|operator|override|private|protected|public|register|sizeof|static|struct|template|this|true|typedef|typeid|typename|union|using|virtual)\>"
 
 # Flow control.
 color brightyellow "\<(if|else|for|while|do|switch|case|default)\>"
@@ -65,6 +66,7 @@ color brightyellow "^\s*#include\s+\".*\"\s*(//.*|/\*.*)?$"
 color red "^\s*#error\s.*$"
 color brightblue "^\s*#(define|undef|error|include|line|pragma)\s" "#"
 color brightblue "^\s*#(if|ifdef|ifndef|elif|else|endif)\s" "\<defined\>"
+color brightblue "^\s*_Pragma"
 
 ## char, string, and escape character/sequence
 ## \e or \x1B or \033 -> Escape, beginning of ANSI escape sequence

--- a/cpp.nanorc
+++ b/cpp.nanorc
@@ -1,8 +1,9 @@
-## Syntax highlighting for C and C++ files.
+## Syntax highlighting for C++ files.
 
-syntax cpp "\.([ch](pp|xx)|C|cc|c\+\+|cu|H|hh|ii?)$"
-header "-\*-.*\<C(\+\+)?((;|[[:blank:]]).*)?-\*-"
-magic "^(C|C\+\+) (source|program)"
+syntax cpp "\.([ch](pp|xx)|C|cc|c\+\+|H|hh|ii)$"
+## File Variable in Emacs
+header "-\*-.*\<mode: c\+\+;.*-\*-"
+magic "^C\+\+ (source|program)"
 comment "//"
 
 # Constants.


### PR DESCRIPTION
- support more keywords
- change the "file_regex", "header_regex", "magic_regex"
- let cpp.nanorc contains more features that c.nanorc has
- fix the regex in highlighting comments, so that
    1. `//` inside (one-line) `/* */` won't be treated as the start of comment
        ```cpp
        /* // */ int a = 0;
        ```
    2. backslash(`\`) behind one-line comment will continue the comment to next line
        ```cpp
        // first line \
            second line
        ```